### PR TITLE
修复关闭时左侧出现一个滚动条宽度空白的问题

### DIFF
--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -281,6 +281,8 @@ class Drawer extends React.PureComponent {
           this.dom.style.transition = 'none';
           switch (placement) {
             case 'right': {
+              // 修复关闭时左侧出现一个滚动条宽度空白的问题
+              this.maskDom.style.transform = `translateX(${- right}px)`;
               this.dom.style.transform = `translateX(${right}px)`;
               this.maskDom.style.right = `${right}px`;
               this.maskDom.style.width = `calc(100% + ${right}px)`;


### PR DESCRIPTION
ant-design/ant-design/tree/drawer
右侧抽屉在关闭时，为防止body宽度被scrollbar影响出现闪动，
draw整体向右transform了一个scrollbar的距离，导致左侧出现空白

change：将mask向左transform一个scrollbar的距离