### PR TITLE
Use a more specific keyframe animation name

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -174,7 +174,7 @@
         opacity: .3;
         width: 100%;
         height: 100%;
-        animation: fadeIn 0.3s @ease-in-out-circ;
+        animation: rcDrawerFadeIn 0.3s @ease-in-out-circ;
         transition: none;
       }
       &-handle {
@@ -192,7 +192,7 @@
   }
 }
 
-@keyframes fadeIn {
+@keyframes rcDrawerFadeIn {
   0% {
     opacity: 0;
   }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -65,7 +65,7 @@ describe('rc-drawer-menu', () => {
       level={[]}
     />);
     const drawer = instance.find('.drawer-content-wrapper').instance();
-    const content = instance.childAt(0).childAt(1).childAt(0);
+    const content = instance.find('.drawer-content');
     content.simulate('touchStart',
       createStartTouchEventObject({ x: 100, y: 0 }));
     content.simulate('touchMove',


### PR DESCRIPTION
Keyframe animations are global identifiers and can't be scoped
to a specific component.  The existing name was very common in
other libraries and could conflict, causing odd-looking mask animations
when opening the drawer.

Also, fixed the tests.

Fixes #41