### PR TITLE
fix body scrollbar width calculation #36

### DIFF
--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -244,7 +244,7 @@ class Drawer extends React.PureComponent {
       // 处理 body 滚动
       const eventArray = ['touchstart'];
       const domArray = [document.body, this.maskDom, this.handlerdom, this.contentDom];
-      const right = getScrollBarSize(1);
+      const right = document.body.getBoundingClientRect().height <= window.innerHeight ? 0 : getScrollBarSize(1);
       let widthTransition = `width ${duration} ${ease}`;
       const trannsformTransition = `transform ${duration} ${ease}`;
       if (open && document.body.style.overflow !== 'hidden') {

--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -244,7 +244,7 @@ class Drawer extends React.PureComponent {
       // 处理 body 滚动
       const eventArray = ['touchstart'];
       const domArray = [document.body, this.maskDom, this.handlerdom, this.contentDom];
-      const right = document.body.getBoundingClientRect().height <= window.innerHeight ? 0 : getScrollBarSize(1);
+      const right = document.body.getClientRects().height <= window.innerHeight ? 0 : getScrollBarSize(1);
       let widthTransition = `width ${duration} ${ease}`;
       const trannsformTransition = `transform ${duration} ${ease}`;
       if (open && document.body.style.overflow !== 'hidden') {

--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -244,7 +244,7 @@ class Drawer extends React.PureComponent {
       // 处理 body 滚动
       const eventArray = ['touchstart'];
       const domArray = [document.body, this.maskDom, this.handlerdom, this.contentDom];
-      const right = document.body.getClientRects().height <= window.innerHeight ? 0 : getScrollBarSize(1);
+      const right = document.body.getClientRects()[0].height <= window.innerHeight ? 0 : getScrollBarSize(1);
       let widthTransition = `width ${duration} ${ease}`;
       const trannsformTransition = `transform ${duration} ${ease}`;
       if (open && document.body.style.overflow !== 'hidden') {


### PR DESCRIPTION
https://github.com/react-component/drawer/blob/0abc35795ab06ebb985f2a03aadc7eb33b93a778/src/Drawer.js#L247

`getScrollBarSize` always return the scrollbar size of your browser, instead of `body` element.  `0` on macOS and `17` on Windows (chrome)

This PR compare the body element's real size (getBoundingClientRect) and the window.innerHeight