### PR TITLE
remove babel runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "classnames": "^2.2.6",
     "rc-util": "^4.11.2",
     "react-lifecycles-compat": "^3.0.4"


### PR DESCRIPTION
it doesn't seem to be in use?

also babel has been on 7 for a while now