### PR TITLE
修复placement: bottom模式样式覆盖造成的显示Bug

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -171,7 +171,8 @@
     }
   }
   &-bottom {
-    bottom:0;
+    top: unset;
+    bottom: 0;
     .@{drawer} {
       &-content-wrapper {
         bottom: 0;


### PR DESCRIPTION
top优先
bottom: 0无法覆盖掉top;
需要干掉top