### PR TITLE
fix: maskstyle opacity 属性与动画组件有冲突

### DIFF
--- a/src/DrawerPopup.tsx
+++ b/src/DrawerPopup.tsx
@@ -213,6 +213,10 @@ export default function DrawerPopup(props: DrawerPopupProps) {
         { className: motionMaskClassName, style: motionMaskStyle },
         maskRef,
       ) => {
+        // opacity 是 CSSMotion组件的关键属性 不应该由coder设置,这里把opacity筛掉 
+        if(maskStyle&&maskStyle.opacity){
+          Reflect.deleteProperty(maskStyle ,"opacity")
+        }
         return (
           <div
             className={classNames(


### PR DESCRIPTION
from https://github.com/ant-design/ant-design/issues/37017
当maskstyle 设置opacity  会覆盖CSSMotion 动画，相关属性冲突