### PR TITLE
fix: prevent scroll when drawer close and focus

### DIFF
--- a/src/Drawer.tsx
+++ b/src/Drawer.tsx
@@ -70,7 +70,7 @@ const Drawer: React.FC<DrawerProps> = props => {
         lastActiveRef.current &&
         !panelRef.current?.contains(lastActiveRef.current)
       ) {
-        lastActiveRef.current?.focus();
+        lastActiveRef.current?.focus({ preventScroll: true });
       }
     };
 


### PR DESCRIPTION
防止 Drawer 关闭时重新聚焦触发元素时页面滚动。

参考：https://github.com/react-component/dialog/blob/646efc72f199818ac88d3b4567b64eb9a2c62b2e/src/Dialog/index.tsx#L78