### PR TITLE
fix(motion): attach motionRef to correct DOM element for CSSMotion lifecycle

### DIFF
--- a/src/DrawerPopup.tsx
+++ b/src/DrawerPopup.tsx
@@ -2,6 +2,7 @@ import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import CSSMotion from '@rc-component/motion';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { fillRef } from '@rc-component/util/lib/ref';
 import * as React from 'react';
 import type { DrawerContextProps } from './context';
 import DrawerContext from './context';
@@ -303,6 +304,14 @@ const DrawerPopup: React.ForwardRefRenderFunction<
     onResizeEnd: resizeConfig.onResizeEnd,
   });
 
+  const fillWrapperRef = React.useCallback(
+    (motionRef: React.Ref<HTMLDivElement>) => (node: HTMLDivElement) => {
+      wrapperRef.current = node;
+      fillRef(motionRef, node);
+    },
+    [],
+  );
+
   // =========================== Events ===========================
   const eventHandlers = {
     onMouseEnter,
@@ -332,7 +341,6 @@ const DrawerPopup: React.ForwardRefRenderFunction<
         const content = (
           <DrawerPanel
             id={id}
-            containerRef={motionRef}
             prefixCls={prefixCls}
             className={clsx(className, drawerClassNames?.section)}
             style={{ ...style, ...styles?.section }}
@@ -344,7 +352,7 @@ const DrawerPopup: React.ForwardRefRenderFunction<
         );
         return (
           <div
-            ref={wrapperRef}
+            ref={fillWrapperRef(motionRef)}
             className={clsx(
               `${prefixCls}-content-wrapper`,
               isDragging && `${prefixCls}-content-wrapper-dragging`,

--- a/src/DrawerPopup.tsx
+++ b/src/DrawerPopup.tsx
@@ -304,7 +304,7 @@ const DrawerPopup: React.ForwardRefRenderFunction<
     onResizeEnd: resizeConfig.onResizeEnd,
   });
 
-  const fillWrapperRef = React.useCallback(
+  const mergeRefs = React.useCallback(
     (motionRef: React.Ref<HTMLDivElement>) => (node: HTMLDivElement) => {
       wrapperRef.current = node;
       fillRef(motionRef, node);
@@ -352,7 +352,7 @@ const DrawerPopup: React.ForwardRefRenderFunction<
         );
         return (
           <div
-            ref={fillWrapperRef(motionRef)}
+            ref={mergeRefs(motionRef)}
             className={clsx(
               `${prefixCls}-content-wrapper`,
               isDragging && `${prefixCls}-content-wrapper-dragging`,


### PR DESCRIPTION
### Summary

After the resize feature was added, `motionRef` was passed to `DrawerPanel` while motion classes/styles were applied to the content-wrapper element. This mismatch caused `CSSMotion` to lose track of the animated DOM node, breaking lifecycle callbacks (`onLeaveEnd`, `onEnterEnd`, etc.).

The fix binds `motionRef` to the content-wrapper — the same element that receives motion classes — by merging it with wrapperRef via a callback ref (`fillWrapperRef`). The stale ref passthrough to `DrawerPanel` has been removed.

### What changed

- Added `fillWrapperRef` callback that merges `wrapperRef` (used by resize/drag) and `motionRef` (used by `CSSMotion`) on the content-wrapper div
- Removed `containerRef={motionRef}` from `DrawerPanel,` which was the source of the ref mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores（代码维护）**
  * 优化抽屉组件对容器与动画/内容的绑定，确保尺寸调整与动画渲染一致，提升交互稳定性与视觉一致性。
  * 精简组件间引用传递，降低实现复杂度并提高可维护性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->