### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
   "dependencies": {
     "@rc-component/motion": "^1.1.4",
     "@rc-component/portal": "^2.1.3",
-    "@rc-component/util": "^1.9.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@ant-design/icons": "^5.3.0",
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^16.3.0",

--- a/src/Drawer.tsx
+++ b/src/Drawer.tsx
@@ -1,6 +1,6 @@
 import type { PortalProps } from '@rc-component/portal';
 import Portal from '@rc-component/portal';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useLayoutEffect } from '@rc-component/util';
 import * as React from 'react';
 import { RefContext } from './context';
 import type {

--- a/src/DrawerPanel.tsx
+++ b/src/DrawerPanel.tsx
@@ -1,8 +1,7 @@
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { RefContext } from './context';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
-import { useComposeRef } from '@rc-component/util/lib/ref';
+import { pickAttrs, useComposeRef } from '@rc-component/util';
 
 export interface DrawerPanelRef {
   focus: VoidFunction;

--- a/src/DrawerPopup.tsx
+++ b/src/DrawerPopup.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import CSSMotion from '@rc-component/motion';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { pickAttrs, useEvent } from '@rc-component/util';
 import * as React from 'react';
 import type { DrawerContextProps } from './context';
 import DrawerContext from './context';
@@ -13,7 +13,6 @@ import DrawerPanel from './DrawerPanel';
 import useDrag from './hooks/useDrag';
 import { parseWidthHeight } from './util';
 import type { DrawerClassNames, DrawerStyles } from './inter';
-import { useEvent } from '@rc-component/util';
 import useFocusable from './hooks/useFocusable';
 
 export type Placement = 'left' | 'right' | 'top' | 'bottom';

--- a/src/hooks/useFocusable.ts
+++ b/src/hooks/useFocusable.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLockFocus } from '@rc-component/util/lib/Dom/focus';
+import { useLockFocus } from '@rc-component/util';
 
 export default function useFocusable(
   getContainer: () => HTMLElement,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 // export this package's api
 import Drawer from './Drawer';
 import type { DrawerProps, Placement } from './Drawer';
+import type { DrawerPopupProps } from './DrawerPopup';
 
-export type { DrawerProps, Placement };
+export type { DrawerProps, DrawerPopupProps, Placement };
 
 export default Drawer;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
-import canUseDom from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom, warning } from '@rc-component/util';
 import type { DrawerProps } from './Drawer';
 
 export function parseWidthHeight(value?: number | string) {

--- a/tests/focus.spec.tsx
+++ b/tests/focus.spec.tsx
@@ -4,8 +4,8 @@ import ReactDOM from 'react-dom';
 import Drawer from '../src';
 
 // Mock useLockFocus to track calls
-jest.mock('@rc-component/util/lib/Dom/focus', () => {
-  const actual = jest.requireActual('@rc-component/util/lib/Dom/focus');
+jest.mock('@rc-component/util', () => {
+  const actual = jest.requireActual('@rc-component/util');
 
   const useLockFocus = (visible: boolean, ...rest: any[]) => {
     (globalThis as any).__useLockFocusVisible = visible;

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, act } from '@testing-library/react';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import React from 'react';
 import type { DrawerProps } from '../src';
 import Drawer from '../src';

--- a/typings/custom.d.ts
+++ b/typings/custom.d.ts
@@ -1,16 +1,1 @@
-declare module '@rc-component/util/lib/KeyCode' {
-  const Ret: { ESC: any; TAB: any };
-  export default Ret;
-}
-
-declare module '@rc-component/util/lib/getScrollBarSize' {
-  const Ret: (b: boolean) => number;
-  export default Ret;
-}
-
-declare module '@rc-component/util/lib/*' {
-  const Ret: any;
-  export default Ret;
-}
-
 declare module 'raf';


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 drawer 中对 rc 包内部路径的依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`。
- 将源码中 `useLayoutEffect`、`pickAttrs`、`useComposeRef`、`useLockFocus`、`useEvent`、`canUseDom`、`warning` 等内部路径引用改为从 `@rc-component/util` 根入口导入。
- 同步调整 focus 测试中的 `useLockFocus` mock 目标，保留原有测试语义。
- 补充导出 `DrawerPopupProps` 类型。
- 移除不再需要的 util deep-path 类型声明。

## 验证

- `npm run lint`
- `npm test -- --runInBand`
- `npm run compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 DrawerPopupProps 类型导出，增强类型系统的完整性。

* **依赖更新**
  * 升级 `@rc-component/util` 至 ^1.11.1 版本。
  * 升级 `@rc-component/father-plugin` 至 ^2.2.0 版本。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/drawer/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->